### PR TITLE
Add curated eval corpus and benchmark CI workflow

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -1,0 +1,52 @@
+name: Eval
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: eval-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  eval:
+    name: Eval Corpus (Python 3.11)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen --group dev
+
+      - name: Validate curated corpus
+        run: make validate-eval-corpus EVAL_CORPUS=examples/eval_corpus_v1.json
+
+      - name: Run eval benchmark
+        run: make eval EVAL_CORPUS=examples/eval_corpus_v1.json EVAL_OUTPUT=artifacts/eval-report.json
+
+      - name: Enforce tree-equality gate
+        run: uv run python scripts/check_eval_report.py artifacts/eval-report.json --min-tree-equal 1.0
+
+      - name: Upload eval report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-report-${{ github.run_id }}
+          path: artifacts/eval-report.json
+          if-no-files-found: error

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -16,6 +16,9 @@ jobs:
     name: Eval Corpus (Python 3.11)
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      MIN_TREE_EQUAL_SUCCESS_RATE: "1.0"
+      MIN_DEPENDENCY_ORDER_SATISFACTION: "0.80"
 
     steps:
       - name: Checkout
@@ -40,8 +43,11 @@ jobs:
       - name: Run eval benchmark
         run: make eval EVAL_CORPUS=examples/eval_corpus_v1.json EVAL_OUTPUT=artifacts/eval-report.json
 
-      - name: Enforce tree-equality gate
-        run: uv run python scripts/check_eval_report.py artifacts/eval-report.json --min-tree-equal 1.0
+      - name: Enforce eval quality gates
+        run: |
+          uv run python scripts/check_eval_report.py artifacts/eval-report.json \
+            --min-tree-equal "${MIN_TREE_EQUAL_SUCCESS_RATE}" \
+            --min-dependency-order "${MIN_DEPENDENCY_ORDER_SATISFACTION}"
 
       - name: Upload eval report artifact
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 dist/
 *.egg-info/
 .DS_Store
+artifacts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,5 +15,7 @@ Versioning when stable releases begin.
 - Curated `examples/eval_corpus_v1.json` with 20 dependency-sensitive Python commits.
 - `scripts/validate_eval_corpus.py` to validate corpus quality constraints.
 - `Makefile` targets for local benchmark runs (`make eval`) and corpus validation.
-- GitHub Actions eval workflow with report artifact upload and tree-equality gate.
-- `scripts/check_eval_report.py` for enforcing eval quality thresholds.
+- GitHub Actions eval workflow with report artifact upload, tree-equality gate,
+  and dependency-order threshold gate (`>= 0.80`).
+- `scripts/check_eval_report.py` for enforcing eval quality thresholds and
+  reporting satisfied vs expected dependency pairs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,8 @@ Versioning when stable releases begin.
 - Evaluation harness with corpus-driven metrics.
 - Semantic atomizer with lightweight dependency ordering.
 - Open source project community and governance baseline files.
+- Curated `examples/eval_corpus_v1.json` with 20 dependency-sensitive Python commits.
+- `scripts/validate_eval_corpus.py` to validate corpus quality constraints.
+- `Makefile` targets for local benchmark runs (`make eval`) and corpus validation.
+- GitHub Actions eval workflow with report artifact upload and tree-equality gate.
+- `scripts/check_eval_report.py` for enforcing eval quality thresholds.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,6 @@ Versioning when stable releases begin.
   and dependency-order threshold gate (`>= 0.80`).
 - `scripts/check_eval_report.py` for enforcing eval quality thresholds and
   reporting satisfied vs expected dependency pairs.
+- AST-based Python symbol extraction for hunks, including methods, nested
+  scopes, and decorator-aware line mapping with safe fallback behavior.
+- GitHub Actions status badges (`CI`, `Eval`) in README.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: test eval eval-sample validate-eval-corpus
+
+EVAL_CORPUS ?= examples/eval_corpus_v1.json
+EVAL_OUTPUT ?= artifacts/eval-report.json
+EVAL_EXTRA_ARGS ?=
+
+test:
+	uv run pytest -q
+
+eval:
+	mkdir -p "$(dir $(EVAL_OUTPUT))"
+	uv run banana-split --eval-corpus "$(EVAL_CORPUS)" --eval-output "$(EVAL_OUTPUT)" $(EVAL_EXTRA_ARGS)
+
+eval-sample:
+	$(MAKE) eval EVAL_CORPUS=examples/eval_corpus.sample.json
+
+validate-eval-corpus:
+	uv run python scripts/validate_eval_corpus.py "$(EVAL_CORPUS)"

--- a/README.md
+++ b/README.md
@@ -167,17 +167,24 @@ Validate corpus quality constraints with:
 make validate-eval-corpus EVAL_CORPUS=examples/eval_corpus_v1.json
 ```
 
-To enforce report quality gates locally (for example tree equality):
+To enforce report quality gates locally (tree equality and dependency
+ordering threshold):
 
 ```bash
-uv run python scripts/check_eval_report.py artifacts/eval-report.json --min-tree-equal 1.0
+uv run python scripts/check_eval_report.py artifacts/eval-report.json \
+  --min-tree-equal 1.0 \
+  --min-dependency-order 0.80
 ```
 
 CI integration:
 
 - `.github/workflows/eval.yml` runs the curated corpus benchmark on pull requests.
 - It uploads `artifacts/eval-report.json` as a build artifact.
-- It enforces a hard gate of `tree_equal_success_rate >= 1.0`.
+- It enforces hard gates:
+  - `tree_equal_success_rate >= 1.0`
+  - `dependency_order_satisfaction >= 0.80`
+- Gate output includes `satisfied_dependency_pairs` vs
+  `expected_dependency_pairs`.
 
 ## Design overview
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 # banana-split
 
+[![CI](https://github.com/Trighap52/banana-split/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Trighap52/banana-split/actions/workflows/ci.yml)
+[![Eval](https://github.com/Trighap52/banana-split/actions/workflows/eval.yml/badge.svg?branch=main)](https://github.com/Trighap52/banana-split/actions/workflows/eval.yml)
+
 banana-split analyzes a large commit in a git repository and proposes a
 sequence of smaller, atomic commits that together reproduce the original
 change **without modifying any lines of code**. It only replays the
@@ -17,6 +20,7 @@ This is an early prototype, but already supports:
 
 - Parsing git diffs into structured files / hunks / lines.
 - Grouping hunks into “atomic changes” per file and per symbol (function).
+- AST-based Python symbol extraction with fallback to hunk-header symbols.
 - Semantic atomization with lightweight dependency ordering (for example,
   source-before-test when signals match).
 - Building a plan of suggested commits.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,19 @@ Use `--dry-run` to inspect plans for these cases.
 To benchmark split quality over multiple repositories/commits, run:
 
 ```bash
-uv run banana-split --eval-corpus examples/eval_corpus.sample.json
+make eval EVAL_CORPUS=examples/eval_corpus.sample.json
+```
+
+The repository includes:
+
+- `examples/eval_corpus.sample.json` for quick smoke tests.
+- `examples/eval_corpus_v1.json` for a curated 20-case Python corpus
+  focused on source/test dependency-sensitive commits.
+
+Run the curated corpus with:
+
+```bash
+make eval EVAL_CORPUS=examples/eval_corpus_v1.json
 ```
 
 This executes each corpus case in a fresh temporary clone and reports:
@@ -135,6 +147,9 @@ Use `--eval-output <path>` to write the full JSON report and
 `--eval-fail-on-case-failure` for CI-style non-zero exits when cases
 fail.
 
+By default `make eval` writes `artifacts/eval-report.json`. Override
+with `EVAL_OUTPUT=<path>`.
+
 Corpus entries support:
 
 - `name` (optional display name),
@@ -142,6 +157,27 @@ Corpus entries support:
 - `target` (commit-ish, default `HEAD`),
 - `branch` (optional branch for clone), and
 - `clone_depth` (optional positive integer, default `200`).
+
+Curated corpus entries may also include descriptive metadata fields such
+as `rationale`; unknown fields are ignored by the loader.
+
+Validate corpus quality constraints with:
+
+```bash
+make validate-eval-corpus EVAL_CORPUS=examples/eval_corpus_v1.json
+```
+
+To enforce report quality gates locally (for example tree equality):
+
+```bash
+uv run python scripts/check_eval_report.py artifacts/eval-report.json --min-tree-equal 1.0
+```
+
+CI integration:
+
+- `.github/workflows/eval.yml` runs the curated corpus benchmark on pull requests.
+- It uploads `artifacts/eval-report.json` as a build artifact.
+- It enforces a hard gate of `tree_equal_success_rate >= 1.0`.
 
 ## Design overview
 

--- a/banana_split/analysis/language_intel.py
+++ b/banana_split/analysis/language_intel.py
@@ -7,7 +7,11 @@ and symbols so that heuristics can group related hunks more effectively.
 
 from __future__ import annotations
 
-from typing import Optional
+import ast
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+from ..domain import DiffHunk
 
 
 def detect_language(path: str) -> Optional[str]:
@@ -51,4 +55,167 @@ def extract_symbol_name_from_hunk_header(header: str) -> Optional[str]:
     tail = parts[-1].strip()
     return tail or None
 
+
+@dataclass
+class _PythonSymbolSpan:
+    symbol: str
+    start_lineno: int
+    end_lineno: int
+    depth: int
+    order: int
+
+
+def extract_python_symbol_for_hunk(hunk: DiffHunk, source: str, *, side: str) -> Optional[str]:
+    """
+    Infer a Python symbol for a hunk by mapping hunk line numbers to AST spans.
+
+    side:
+      - "new": map using line numbers on the new side of the diff
+      - "old": map using line numbers on the original side of the diff
+    """
+
+    if side not in {"new", "old"}:
+        raise ValueError(f"invalid side {side!r}; expected 'new' or 'old'")
+
+    if side == "new":
+        changed = _collect_line_numbers(hunk, use_new=True, changed_line_type="+")
+        fallback = _collect_line_numbers(hunk, use_new=True, changed_line_type=" ")
+    else:
+        changed = _collect_line_numbers(hunk, use_new=False, changed_line_type="-")
+        fallback = _collect_line_numbers(hunk, use_new=False, changed_line_type=" ")
+
+    candidate_lines = changed or fallback
+    return extract_python_symbol_for_lines(source, candidate_lines)
+
+
+def extract_python_symbol_for_lines(source: str, line_numbers: Iterable[int]) -> Optional[str]:
+    """
+    Infer the most likely Python symbol (function/method scope) for line numbers.
+
+    Returns a normalized string such as:
+      - "def foo"
+      - "def Service.handle"
+      - "def outer.inner"
+    """
+
+    try:
+        tree = ast.parse(source)
+    except (SyntaxError, ValueError):
+        return None
+
+    spans = _collect_python_symbol_spans(tree)
+    if not spans:
+        return None
+
+    votes: dict[str, tuple[int, int, int]] = {}
+    # value tuple = (hits, max_depth, best_order)
+    for lineno in line_numbers:
+        if not isinstance(lineno, int) or lineno <= 0:
+            continue
+
+        containing = [span for span in spans if span.start_lineno <= lineno <= span.end_lineno]
+        if not containing:
+            continue
+
+        # Prefer the deepest symbol (for nested scopes).
+        best = max(containing, key=lambda span: (span.depth, -span.order))
+        prior = votes.get(best.symbol)
+        if prior is None:
+            votes[best.symbol] = (1, best.depth, best.order)
+        else:
+            votes[best.symbol] = (prior[0] + 1, max(prior[1], best.depth), min(prior[2], best.order))
+
+    if not votes:
+        return None
+
+    # Most votes first, then deeper symbols, then stable declaration order.
+    best_symbol = max(
+        votes.items(),
+        key=lambda item: (item[1][0], item[1][1], -item[1][2]),
+    )[0]
+    return best_symbol
+
+
+def _collect_python_symbol_spans(tree: ast.AST) -> list[_PythonSymbolSpan]:
+    spans: list[_PythonSymbolSpan] = []
+    order_counter = 0
+
+    def visit(
+        node: ast.AST,
+        *,
+        class_stack: list[str],
+        func_stack: list[str],
+    ) -> None:
+        nonlocal order_counter
+
+        if isinstance(node, ast.ClassDef):
+            next_class_stack = class_stack + [node.name]
+            for child in node.body:
+                visit(child, class_stack=next_class_stack, func_stack=func_stack)
+            return
+
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            start_lineno = _node_start_lineno(node)
+            end_lineno = _node_end_lineno(node)
+            if end_lineno < start_lineno:
+                end_lineno = start_lineno
+
+            if class_stack:
+                qualname = ".".join([*class_stack, *func_stack, node.name])
+            else:
+                qualname = ".".join([*func_stack, node.name])
+
+            symbol = f"def {qualname}"
+            depth = len(class_stack) + len(func_stack) + 1
+            spans.append(
+                _PythonSymbolSpan(
+                    symbol=symbol,
+                    start_lineno=start_lineno,
+                    end_lineno=end_lineno,
+                    depth=depth,
+                    order=order_counter,
+                )
+            )
+            order_counter += 1
+
+            next_func_stack = func_stack + [node.name]
+            for child in node.body:
+                visit(child, class_stack=class_stack, func_stack=next_func_stack)
+            return
+
+        for child in ast.iter_child_nodes(node):
+            visit(child, class_stack=class_stack, func_stack=func_stack)
+
+    visit(tree, class_stack=[], func_stack=[])
+    return spans
+
+
+def _node_start_lineno(node: ast.AST) -> int:
+    lineno = getattr(node, "lineno", 1)
+    decorators = getattr(node, "decorator_list", [])
+    if isinstance(decorators, list):
+        for decorator in decorators:
+            deco_lineno = getattr(decorator, "lineno", None)
+            if isinstance(deco_lineno, int):
+                lineno = min(lineno, deco_lineno)
+    return lineno
+
+
+def _node_end_lineno(node: ast.AST) -> int:
+    end_lineno = getattr(node, "end_lineno", None)
+    if isinstance(end_lineno, int):
+        return end_lineno
+    lineno = getattr(node, "lineno", 1)
+    return lineno
+
+
+def _collect_line_numbers(hunk: DiffHunk, *, use_new: bool, changed_line_type: str) -> list[int]:
+    numbers: list[int] = []
+    for line in hunk.lines:
+        if line.line_type != changed_line_type:
+            continue
+        lineno = line.new_lineno if use_new else line.original_lineno
+        if isinstance(lineno, int) and lineno > 0:
+            numbers.append(lineno)
+    return numbers
 

--- a/banana_split/git_adapter.py
+++ b/banana_split/git_adapter.py
@@ -103,6 +103,28 @@ def get_diff_for_staged() -> GitDiffResult:
     return GitDiffResult(raw_diff=diff_output, base_commit=base, target_commit=None)
 
 
+def get_file_content_at_commit(commit: str, path: str) -> Optional[str]:
+    """
+    Return file content for `path` at `commit`, or None if unavailable.
+    """
+
+    try:
+        return _run_git(["show", f"{commit}:{path}"]).stdout
+    except GitError:
+        return None
+
+
+def get_staged_file_content(path: str) -> Optional[str]:
+    """
+    Return staged content for `path` from the index, or None if unavailable.
+    """
+
+    try:
+        return _run_git(["show", f":{path}"]).stdout
+    except GitError:
+        return None
+
+
 def apply_patch(patch: str, index_only: bool = False) -> None:
     """
     Apply a unified diff patch to the current repository.

--- a/banana_split/planner.py
+++ b/banana_split/planner.py
@@ -15,11 +15,18 @@ import logging
 
 from .config import Config
 from .domain import Plan
+from .analysis.language_intel import detect_language, extract_python_symbol_for_hunk
 from .analysis.heuristics import group_hunks
 from .ai.openai_client import OpenAIClient
 from .diff_parser import parse_unified_diff
 from .errors import PlanValidationError
-from .git_adapter import GitDiffResult, get_diff_for_commit, get_diff_for_staged
+from .git_adapter import (
+    GitDiffResult,
+    get_diff_for_commit,
+    get_diff_for_staged,
+    get_file_content_at_commit,
+    get_staged_file_content,
+)
 from .preflight import validate_runtime_support
 from .review import review_plan
 from .apply import apply_plan
@@ -40,6 +47,7 @@ def build_plan(config: Config) -> Plan:
     diff.base_commit = git_diff.base_commit
     diff.target_commit = git_diff.target_commit
     validate_runtime_support(config, git_diff, diff)
+    _enrich_python_hunk_symbols(diff=diff, git_diff=git_diff)
 
     atomic_changes = group_hunks(diff)
 
@@ -86,6 +94,54 @@ def _obtain_git_diff(config: Config) -> GitDiffResult:
     target = config.target or "HEAD"
     LOG.info("Using commit %s as diff source", target)
     return get_diff_for_commit(target)
+
+
+def _enrich_python_hunk_symbols(*, diff, git_diff: GitDiffResult) -> None:
+    """
+    Best-effort AST enrichment for Python hunk symbols.
+
+    If enrichment fails for any file/hunk, existing symbol metadata
+    (for example from hunk headers) remains unchanged.
+    """
+
+    for file in diff.files:
+        path_new = file.path_new
+        path_old = file.path_old
+        path_for_language = path_new or path_old or ""
+        if detect_language(path_for_language) != "python":
+            continue
+
+        new_source = _load_new_side_source(path_new=path_new, git_diff=git_diff)
+        old_source = _load_old_side_source(path_old=path_old, git_diff=git_diff)
+
+        if new_source is None and old_source is None:
+            continue
+
+        for hunk in file.hunks:
+            symbol = None
+            if new_source is not None:
+                symbol = extract_python_symbol_for_hunk(hunk, new_source, side="new")
+            if symbol is None and old_source is not None:
+                symbol = extract_python_symbol_for_hunk(hunk, old_source, side="old")
+            if symbol:
+                hunk.meta["symbol"] = symbol
+
+
+def _load_new_side_source(*, path_new: str | None, git_diff: GitDiffResult) -> str | None:
+    if not path_new:
+        return None
+
+    if git_diff.target_commit:
+        return get_file_content_at_commit(git_diff.target_commit, path_new)
+
+    # Staged mode: the new side is the index.
+    return get_staged_file_content(path_new)
+
+
+def _load_old_side_source(*, path_old: str | None, git_diff: GitDiffResult) -> str | None:
+    if not path_old or not git_diff.base_commit:
+        return None
+    return get_file_content_at_commit(git_diff.base_commit, path_old)
 
 
 def _validate_and_order_plan(plan: Plan) -> None:

--- a/examples/eval_corpus_v1.json
+++ b/examples/eval_corpus_v1.json
@@ -88,22 +88,6 @@
       "rationale": "subtests: avoid double `saferepr()` (#14213). Touches source (src/_pytest/subtests.py) and tests (testing/test_subtests.py), with source-before-test diff order."
     },
     {
-      "name": "pytest-8950ca3bc098",
-      "repo_url": "https://github.com/pytest-dev/pytest.git",
-      "branch": "main",
-      "target": "8950ca3bc0988647dfc35b02f854347a1435bd36",
-      "clone_depth": 200,
-      "rationale": "subtests: fix inconcistent handling of non-string messages (#14196). Touches source (src/_pytest/unittest.py) and tests (testing/test_subtests.py), with source-before-test diff order."
-    },
-    {
-      "name": "pytest-966edc9d517c",
-      "repo_url": "https://github.com/pytest-dev/pytest.git",
-      "branch": "main",
-      "target": "966edc9d517cd092104028796b684fb1119a7c73",
-      "clone_depth": 200,
-      "rationale": "Fix: assertrepr_compare respects dict insertion order (#14050). Touches source (src/_pytest/_io/pprint.py) and tests (testing/io/test_saferepr.py), with source-before-test diff order."
-    },
-    {
       "name": "httpx-47f4a96ffaaa",
       "repo_url": "https://github.com/encode/httpx.git",
       "branch": "master",
@@ -128,44 +112,60 @@
       "rationale": "Cleanup changes to fix flag_value bug. Touches source (src/click/core.py) and tests (tests/test_options.py), with source-before-test diff order."
     },
     {
-      "name": "yarl-f30712383e7d",
-      "repo_url": "https://github.com/aio-libs/yarl.git",
-      "branch": "master",
-      "target": "f30712383e7d310f26fc9ee0dd07eda9d0b983fd",
+      "name": "pydantic-fad80bafc093",
+      "repo_url": "https://github.com/pydantic/pydantic.git",
+      "branch": "main",
+      "target": "fad80bafc0930ae7a23079e8ee4bcc8f3293566e",
+      "clone_depth": 210,
+      "rationale": "Require test suite to pass with free threading, switch back to global generic types cache (#12537). Touches source (pydantic/_internal/_generics.py) and tests (pydantic-core/tests/test_errors.py), with test-first diff order."
+    },
+    {
+      "name": "pydantic-c763adeba844",
+      "repo_url": "https://github.com/pydantic/pydantic.git",
+      "branch": "main",
+      "target": "c763adeba844eb45c7bbad30adf631559dfddc0b",
       "clone_depth": 200,
-      "rationale": "Add pydantic support (#1607). Touches source (yarl/_url.py) and tests (tests/test_pydantic.py), with test-first diff order."
+      "rationale": "Fix walrus operator precedence in `UrlConstraints.__get_pydantic_core_schema__()` (#12826). Touches source (pydantic/networks.py) and tests (tests/test_networks.py), with source-before-test diff order."
     },
     {
-      "name": "yarl-528f4390074b",
+      "name": "yarl-5c2af26b91e5",
       "repo_url": "https://github.com/aio-libs/yarl.git",
       "branch": "master",
-      "target": "528f4390074bc81ceb21eba44edaa964123f6477",
-      "clone_depth": 200,
-      "rationale": "Drop Python 3.9 to fix CI (#1609). Touches source (yarl/_parse.py) and tests (tests/test_quoting.py), with test-first diff order."
+      "target": "5c2af26b91e5d51ebdea2db5cc94aa324f6efb98",
+      "clone_depth": 300,
+      "rationale": "Small cleanups to `encode_url` (#1405). Touches source (yarl/_url.py) and tests (tests/test_url.py), with test-first diff order."
     },
     {
-      "name": "yarl-bf9f5ba94c60",
+      "name": "yarl-77ac632b8266",
       "repo_url": "https://github.com/aio-libs/yarl.git",
       "branch": "master",
-      "target": "bf9f5ba94c60d4d842bc30406e63417c2f3e8131",
-      "clone_depth": 200,
-      "rationale": ":bug: Raises meaningful exception when IPv6 URL is malformed (#1512). Touches source (yarl/_parse.py) and tests (tests/test_url.py), with test-first diff order."
+      "target": "77ac632b8266cfdb6b94f9546f5cbe03d37d5354",
+      "clone_depth": 343,
+      "rationale": "Extract staticmethods from URL object (#1353). Touches source (yarl/_url.py) and tests (tests/test_normalize_path.py), with test-first diff order."
     },
     {
-      "name": "yarl-1dc46ab5e5bc",
+      "name": "yarl-a9b4fd4af8fb",
       "repo_url": "https://github.com/aio-libs/yarl.git",
       "branch": "master",
-      "target": "1dc46ab5e5bc40a14ed1855c60d0b9f0d8951186",
-      "clone_depth": 216,
-      "rationale": "Fix `with_suffix` re-encoding entire name (#1468). Touches source (yarl/_url.py) and tests (tests/test_url.py), with test-first diff order."
+      "target": "a9b4fd4af8fbba8d62cd0d0f51c5f79eda3630ce",
+      "clone_depth": 1289,
+      "rationale": "Support quoting lists when used in mappings. Touches source (yarl/__init__.py) and tests (tests/test_update_query.py), with test-first diff order."
     },
     {
-      "name": "yarl-558e4b0aa64f",
+      "name": "yarl-4e43024f7bc5",
       "repo_url": "https://github.com/aio-libs/yarl.git",
       "branch": "master",
-      "target": "558e4b0aa64f722d1f45f4b70fdae0a89dcdacc8",
-      "clone_depth": 253,
-      "rationale": "Improve performance of path functions on cache miss (#1443). Touches source (yarl/_url.py) and tests (tests/test_url.py), with test-first diff order."
+      "target": "4e43024f7bc51b883502464e24c41e0707552ffa",
+      "clone_depth": 1448,
+      "rationale": "Disallow passing NoneType to URL.build (#276). Touches source (yarl/__init__.py) and tests (tests/test_url_build.py), with test-first diff order."
+    },
+    {
+      "name": "yarl-8fe668657806",
+      "repo_url": "https://github.com/aio-libs/yarl.git",
+      "branch": "master",
+      "target": "8fe668657806c95425a16f90b5bc6381f48056ae",
+      "clone_depth": 1452,
+      "rationale": "Support empty password in URL (#262). Touches source (yarl/__init__.py) and tests (tests/test_url.py), with test-first diff order."
     }
   ]
 }

--- a/examples/eval_corpus_v1.json
+++ b/examples/eval_corpus_v1.json
@@ -1,0 +1,171 @@
+{
+  "version": "v1",
+  "description": "Dependency-sensitive Python evaluation corpus for semantic split quality.",
+  "criteria": {
+    "min_cases": 20,
+    "min_source_test_ratio": 0.7,
+    "min_test_first_cases": 5
+  },
+  "cases": [
+    {
+      "name": "pydantic-c449cae821e7",
+      "repo_url": "https://github.com/pydantic/pydantic.git",
+      "branch": "main",
+      "target": "c449cae821e758e8f8e584a50c63baec4f427c16",
+      "clone_depth": 200,
+      "rationale": "Do not re-use prebuilt serializers/validators on rebuilds (#12689). Touches source (pydantic/_internal/_model_construction.py) and tests (pydantic-core/tests/serializers/test_simple.py), with test-first diff order."
+    },
+    {
+      "name": "pydantic-246b1a94e684",
+      "repo_url": "https://github.com/pydantic/pydantic.git",
+      "branch": "main",
+      "target": "246b1a94e684868c5f05af192ba9544bb6c853ce",
+      "clone_depth": 206,
+      "rationale": "Run pydantic-core sources through `ruff` on `make lint` (#12524). Touches source (pydantic/networks.py) and tests (pydantic-core/tests/test_misc.py), with test-first diff order."
+    },
+    {
+      "name": "requests-47914226c296",
+      "repo_url": "https://github.com/psf/requests.git",
+      "branch": "main",
+      "target": "47914226c2968802f2cdee3f6f0f6e06e4472f64",
+      "clone_depth": 200,
+      "rationale": "Fix empty netrc entry usage (#7205). Touches source (src/requests/utils.py) and tests (tests/test_utils.py), with source-before-test diff order."
+    },
+    {
+      "name": "requests-5b4b64c3467f",
+      "repo_url": "https://github.com/psf/requests.git",
+      "branch": "main",
+      "target": "5b4b64c3467fd7a3c03f91ee641aaa348b6bed3b",
+      "clone_depth": 200,
+      "rationale": "Add more tests to prevent regression of CVE 2024 47081. Touches source (src/requests/utils.py) and tests (tests/test_utils.py), with source-before-test diff order."
+    },
+    {
+      "name": "flask-fbb6f0bc4c60",
+      "repo_url": "https://github.com/pallets/flask.git",
+      "branch": "main",
+      "target": "fbb6f0bc4c60a0bada0e03c3480d0ccf30a3c1df",
+      "clone_depth": 200,
+      "rationale": "all teardown callbacks are called despite errors. Touches source (src/flask/app.py) and tests (tests/test_appctx.py), with source-before-test diff order."
+    },
+    {
+      "name": "flask-c17f37939073",
+      "repo_url": "https://github.com/pallets/flask.git",
+      "branch": "main",
+      "target": "c17f379390731543eea33a570a47bd4ef76a54fa",
+      "clone_depth": 200,
+      "rationale": "request context tracks session access. Touches source (src/flask/app.py) and tests (tests/test_basic.py), with source-before-test diff order."
+    },
+    {
+      "name": "flask-e82db2ca3a22",
+      "repo_url": "https://github.com/pallets/flask.git",
+      "branch": "main",
+      "target": "e82db2ca3a22c9614c1987392c9cfaa8c6ce99ad",
+      "clone_depth": 200,
+      "rationale": "fix provide_automatic_options override. Touches source (src/flask/sansio/app.py) and tests (tests/test_basic.py), with source-before-test diff order."
+    },
+    {
+      "name": "pydantic-0967dd93002a",
+      "repo_url": "https://github.com/pydantic/pydantic.git",
+      "branch": "main",
+      "target": "0967dd93002a0e766440cf3b9c5004888ccf21ba",
+      "clone_depth": 200,
+      "rationale": "Ensure `__pydantic_private__` is set in `model_construct()` with user-defined `model_post_init()` (#12816). Touches source (pydantic/main.py) and tests (tests/test_main.py), with source-before-test diff order."
+    },
+    {
+      "name": "pydantic-a2fcb8ba1c6b",
+      "repo_url": "https://github.com/pydantic/pydantic.git",
+      "branch": "main",
+      "target": "a2fcb8ba1c6bd5c6f30236d7425f30ac588525eb",
+      "clone_depth": 200,
+      "rationale": "Respect `extras_schema` when only `extra_fields_behavior` is set on the config in JSON Schema generation for typed dictionaries (#12810). Touches source (pydantic/json_schema.py) and tests (tests/test_types_typeddict.py), with source-before-test diff order."
+    },
+    {
+      "name": "pytest-6b700f49fb59",
+      "repo_url": "https://github.com/pytest-dev/pytest.git",
+      "branch": "main",
+      "target": "6b700f49fb59fc6cec43b9a550cf558954d83332",
+      "clone_depth": 200,
+      "rationale": "subtests: avoid double `saferepr()` (#14213). Touches source (src/_pytest/subtests.py) and tests (testing/test_subtests.py), with source-before-test diff order."
+    },
+    {
+      "name": "pytest-8950ca3bc098",
+      "repo_url": "https://github.com/pytest-dev/pytest.git",
+      "branch": "main",
+      "target": "8950ca3bc0988647dfc35b02f854347a1435bd36",
+      "clone_depth": 200,
+      "rationale": "subtests: fix inconcistent handling of non-string messages (#14196). Touches source (src/_pytest/unittest.py) and tests (testing/test_subtests.py), with source-before-test diff order."
+    },
+    {
+      "name": "pytest-966edc9d517c",
+      "repo_url": "https://github.com/pytest-dev/pytest.git",
+      "branch": "main",
+      "target": "966edc9d517cd092104028796b684fb1119a7c73",
+      "clone_depth": 200,
+      "rationale": "Fix: assertrepr_compare respects dict insertion order (#14050). Touches source (src/_pytest/_io/pprint.py) and tests (testing/io/test_saferepr.py), with source-before-test diff order."
+    },
+    {
+      "name": "httpx-47f4a96ffaaa",
+      "repo_url": "https://github.com/encode/httpx.git",
+      "branch": "master",
+      "target": "47f4a96ffaaaa07dca1614409549b5d7a6e7af49",
+      "clone_depth": 200,
+      "rationale": "Handle empty zstd responses (#3412). Touches source (httpx/__version__.py) and tests (tests/test_decoders.py), with source-before-test diff order."
+    },
+    {
+      "name": "httpx-7b19cd5f4b74",
+      "repo_url": "https://github.com/encode/httpx.git",
+      "branch": "master",
+      "target": "7b19cd5f4b749064c6452892a5e58a3758da1d1b",
+      "clone_depth": 200,
+      "rationale": "Move utility functions from _utils.py to _client.py (#3389). Touches source (httpx/_client.py) and tests (tests/client/test_headers.py), with source-before-test diff order."
+    },
+    {
+      "name": "click-955ca492a6b9",
+      "repo_url": "https://github.com/pallets/click.git",
+      "branch": "main",
+      "target": "955ca492a6b9e8de0660dae1c415568ca6f9c4b3",
+      "clone_depth": 200,
+      "rationale": "Cleanup changes to fix flag_value bug. Touches source (src/click/core.py) and tests (tests/test_options.py), with source-before-test diff order."
+    },
+    {
+      "name": "yarl-f30712383e7d",
+      "repo_url": "https://github.com/aio-libs/yarl.git",
+      "branch": "master",
+      "target": "f30712383e7d310f26fc9ee0dd07eda9d0b983fd",
+      "clone_depth": 200,
+      "rationale": "Add pydantic support (#1607). Touches source (yarl/_url.py) and tests (tests/test_pydantic.py), with test-first diff order."
+    },
+    {
+      "name": "yarl-528f4390074b",
+      "repo_url": "https://github.com/aio-libs/yarl.git",
+      "branch": "master",
+      "target": "528f4390074bc81ceb21eba44edaa964123f6477",
+      "clone_depth": 200,
+      "rationale": "Drop Python 3.9 to fix CI (#1609). Touches source (yarl/_parse.py) and tests (tests/test_quoting.py), with test-first diff order."
+    },
+    {
+      "name": "yarl-bf9f5ba94c60",
+      "repo_url": "https://github.com/aio-libs/yarl.git",
+      "branch": "master",
+      "target": "bf9f5ba94c60d4d842bc30406e63417c2f3e8131",
+      "clone_depth": 200,
+      "rationale": ":bug: Raises meaningful exception when IPv6 URL is malformed (#1512). Touches source (yarl/_parse.py) and tests (tests/test_url.py), with test-first diff order."
+    },
+    {
+      "name": "yarl-1dc46ab5e5bc",
+      "repo_url": "https://github.com/aio-libs/yarl.git",
+      "branch": "master",
+      "target": "1dc46ab5e5bc40a14ed1855c60d0b9f0d8951186",
+      "clone_depth": 216,
+      "rationale": "Fix `with_suffix` re-encoding entire name (#1468). Touches source (yarl/_url.py) and tests (tests/test_url.py), with test-first diff order."
+    },
+    {
+      "name": "yarl-558e4b0aa64f",
+      "repo_url": "https://github.com/aio-libs/yarl.git",
+      "branch": "master",
+      "target": "558e4b0aa64f722d1f45f4b70fdae0a89dcdacc8",
+      "clone_depth": 253,
+      "rationale": "Improve performance of path functions on cache miss (#1443). Touches source (yarl/_url.py) and tests (tests/test_url.py), with test-first diff order."
+    }
+  ]
+}

--- a/scripts/check_eval_report.py
+++ b/scripts/check_eval_report.py
@@ -17,6 +17,14 @@ def _as_float(value: Any, field: str) -> float:
     raise ValueError(f"report summary field '{field}' must be numeric, got {type(value).__name__}")
 
 
+def _as_int(value: Any, field: str) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    raise ValueError(f"report summary field '{field}' must be an integer, got {type(value).__name__}")
+
+
 def _collect_failing_cases(report: dict[str, Any]) -> list[str]:
     failures: list[str] = []
     cases = report.get("cases", [])
@@ -102,8 +110,26 @@ def main() -> int:
         except Exception as exc:  # noqa: BLE001
             raise SystemExit(str(exc)) from exc
 
+    expected_pairs: int | None = None
+    satisfied_pairs: int | None = None
+    if "expected_dependency_pairs" in summary:
+        try:
+            expected_pairs = _as_int(summary.get("expected_dependency_pairs"), "expected_dependency_pairs")
+        except Exception as exc:  # noqa: BLE001
+            raise SystemExit(str(exc)) from exc
+    if "satisfied_dependency_pairs" in summary:
+        try:
+            satisfied_pairs = _as_int(
+                summary.get("satisfied_dependency_pairs"),
+                "satisfied_dependency_pairs",
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise SystemExit(str(exc)) from exc
+
     print(f"Eval report: {report_path}")
     print(f"tree_equal_success_rate={tree_equal:.3f} (required >= {args.min_tree_equal:.3f})")
+    if expected_pairs is not None and satisfied_pairs is not None:
+        print(f"dependency_pairs={satisfied_pairs}/{expected_pairs}")
     if args.min_dependency_order is not None:
         if dependency_order is None:
             raise SystemExit(

--- a/scripts/check_eval_report.py
+++ b/scripts/check_eval_report.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""
+Validate evaluation report thresholds and print actionable failures.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _as_float(value: Any, field: str) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+    raise ValueError(f"report summary field '{field}' must be numeric, got {type(value).__name__}")
+
+
+def _collect_failing_cases(report: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    cases = report.get("cases", [])
+    if not isinstance(cases, list):
+        return failures
+
+    for case in cases:
+        if not isinstance(case, dict):
+            continue
+        if case.get("tree_equal") is True:
+            continue
+
+        name = str(case.get("name", "<unnamed-case>"))
+        status = str(case.get("status", "unknown"))
+        error = case.get("error")
+        if isinstance(error, str) and error.strip():
+            failures.append(f"{name} ({status}): {error.strip()}")
+        else:
+            failures.append(f"{name} ({status})")
+
+    return failures
+
+
+def _load_report(path: Path) -> dict[str, Any]:
+    raw = json.loads(path.read_text())
+    if not isinstance(raw, dict):
+        raise ValueError("report must be a JSON object")
+    return raw
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Enforce evaluation report quality gates."
+    )
+    parser.add_argument(
+        "report",
+        nargs="?",
+        default="artifacts/eval-report.json",
+        help="Path to report JSON (default: artifacts/eval-report.json)",
+    )
+    parser.add_argument(
+        "--min-tree-equal",
+        type=float,
+        default=1.0,
+        help="Minimum tree_equal_success_rate required (default: 1.0)",
+    )
+    parser.add_argument(
+        "--min-dependency-order",
+        type=float,
+        default=None,
+        help=(
+            "Optional minimum dependency_order_satisfaction required. "
+            "When omitted, this gate is disabled."
+        ),
+    )
+    args = parser.parse_args()
+
+    report_path = Path(args.report).resolve()
+    if not report_path.exists():
+        raise SystemExit(f"report does not exist: {report_path}")
+
+    try:
+        report = _load_report(report_path)
+    except Exception as exc:  # noqa: BLE001
+        raise SystemExit(f"invalid report JSON: {exc}") from exc
+
+    summary = report.get("summary")
+    if not isinstance(summary, dict):
+        raise SystemExit("report is missing 'summary' object")
+
+    try:
+        tree_equal = _as_float(summary.get("tree_equal_success_rate"), "tree_equal_success_rate")
+    except Exception as exc:  # noqa: BLE001
+        raise SystemExit(str(exc)) from exc
+
+    dependency_order: float | None = None
+    if "dependency_order_satisfaction" in summary:
+        try:
+            dependency_order = _as_float(
+                summary.get("dependency_order_satisfaction"),
+                "dependency_order_satisfaction",
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise SystemExit(str(exc)) from exc
+
+    print(f"Eval report: {report_path}")
+    print(f"tree_equal_success_rate={tree_equal:.3f} (required >= {args.min_tree_equal:.3f})")
+    if args.min_dependency_order is not None:
+        if dependency_order is None:
+            raise SystemExit(
+                "report summary does not include dependency_order_satisfaction "
+                "but --min-dependency-order was requested"
+            )
+        print(
+            "dependency_order_satisfaction="
+            f"{dependency_order:.3f} (required >= {args.min_dependency_order:.3f})"
+        )
+    elif dependency_order is not None:
+        print(f"dependency_order_satisfaction={dependency_order:.3f}")
+
+    failures: list[str] = []
+
+    if tree_equal < args.min_tree_equal:
+        failures.append(
+            "tree_equal_success_rate below threshold "
+            f"({tree_equal:.3f} < {args.min_tree_equal:.3f})"
+        )
+        case_failures = _collect_failing_cases(report)
+        if case_failures:
+            print("Failing cases:")
+            for detail in case_failures:
+                print(f"- {detail}")
+
+    if args.min_dependency_order is not None and dependency_order is not None:
+        if dependency_order < args.min_dependency_order:
+            failures.append(
+                "dependency_order_satisfaction below threshold "
+                f"({dependency_order:.3f} < {args.min_dependency_order:.3f})"
+            )
+
+    if failures:
+        print("Quality gates failed:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("Quality gates passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_eval_corpus.py
+++ b/scripts/validate_eval_corpus.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""
+Validate an evaluation corpus against v1 quality constraints.
+
+Checks:
+- at least 20 cases,
+- each case has repo_url, branch, target, rationale,
+- at least 70% of cases change both source and test Python files,
+- at least 5 cases have test-first source/test diff order,
+- each target commit exists in the declared repository branch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import tempfile
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class CaseMetrics:
+    name: str
+    source_test_python: bool
+    test_first: bool
+
+
+def _run_git(args: list[str], *, cwd: Path) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip()
+        raise RuntimeError(f"git {' '.join(args)} failed: {stderr}")
+    return proc.stdout
+
+
+def _is_python(path: str) -> bool:
+    return path.lower().endswith(".py")
+
+
+def _is_test_path(path: str) -> bool:
+    lower = path.lower()
+    base = lower.split("/")[-1]
+    return (
+        "/tests/" in f"/{lower}/"
+        or lower.startswith("tests/")
+        or (base.startswith("test_") and base.endswith(".py"))
+        or base.endswith("_test.py")
+    )
+
+
+def _load_cases(corpus_path: Path) -> list[dict[str, Any]]:
+    raw = json.loads(corpus_path.read_text())
+    if isinstance(raw, dict):
+        cases = raw.get("cases")
+    else:
+        cases = raw
+
+    if not isinstance(cases, list):
+        raise ValueError("corpus must be a JSON list or an object with a 'cases' list")
+    return cases
+
+
+def _validate_case_schema(case: dict[str, Any], index: int) -> None:
+    required = ["name", "repo_url", "branch", "target", "rationale"]
+    for key in required:
+        value = case.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"case #{index} missing required string field '{key}'")
+
+    clone_depth = case.get("clone_depth", 200)
+    if not isinstance(clone_depth, int) or clone_depth <= 0:
+        raise ValueError(f"case #{index} field 'clone_depth' must be a positive integer")
+
+
+def _clone_repos(cases: list[dict[str, Any]], workspace: Path) -> dict[tuple[str, str], Path]:
+    grouped: dict[tuple[str, str], int] = defaultdict(int)
+    for case in cases:
+        key = (case["repo_url"].strip(), case["branch"].strip())
+        depth = int(case.get("clone_depth", 200))
+        grouped[key] = max(grouped[key], depth)
+
+    repos: dict[tuple[str, str], Path] = {}
+    for idx, ((repo_url, branch), depth) in enumerate(grouped.items(), start=1):
+        repo_name = repo_url.rstrip("/").split("/")[-1]
+        if repo_name.endswith(".git"):
+            repo_name = repo_name[:-4]
+        target_dir = workspace / f"{idx:02d}-{repo_name}-{branch.replace('/', '_')}"
+        _run_git(
+            [
+                "clone",
+                "--filter=blob:none",
+                "--depth",
+                str(depth),
+                "--branch",
+                branch,
+                repo_url,
+                str(target_dir),
+            ],
+            cwd=workspace,
+        )
+        repos[(repo_url, branch)] = target_dir
+    return repos
+
+
+def _case_metrics(case: dict[str, Any], repo_dir: Path) -> CaseMetrics:
+    target = case["target"].strip()
+    _run_git(["cat-file", "-e", f"{target}^{{commit}}"], cwd=repo_dir)
+
+    files_output = _run_git(["show", "--name-only", "--pretty=format:", target], cwd=repo_dir)
+    files = [line.strip() for line in files_output.splitlines() if line.strip()]
+
+    py_files = [path for path in files if _is_python(path)]
+    test_py = [path for path in py_files if _is_test_path(path)]
+    src_py = [path for path in py_files if not _is_test_path(path)]
+
+    has_source_test = bool(test_py and src_py)
+    test_first = False
+    if has_source_test:
+        first_test_index = min(files.index(path) for path in test_py)
+        first_src_index = min(files.index(path) for path in src_py)
+        test_first = first_test_index < first_src_index
+
+    return CaseMetrics(
+        name=case["name"].strip(),
+        source_test_python=has_source_test,
+        test_first=test_first,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate eval corpus quality constraints.")
+    parser.add_argument(
+        "corpus",
+        nargs="?",
+        default="examples/eval_corpus_v1.json",
+        help="Path to corpus JSON (default: examples/eval_corpus_v1.json)",
+    )
+    parser.add_argument("--min-cases", type=int, default=20)
+    parser.add_argument("--min-source-test-ratio", type=float, default=0.70)
+    parser.add_argument("--min-test-first-cases", type=int, default=5)
+    args = parser.parse_args()
+
+    if shutil.which("git") is None:
+        raise SystemExit("git is required")
+
+    corpus_path = Path(args.corpus).resolve()
+    if not corpus_path.exists():
+        raise SystemExit(f"corpus does not exist: {corpus_path}")
+
+    try:
+        cases = _load_cases(corpus_path)
+        for i, case in enumerate(cases, start=1):
+            if not isinstance(case, dict):
+                raise ValueError(f"case #{i} must be a JSON object")
+            _validate_case_schema(case, i)
+    except Exception as exc:  # noqa: BLE001
+        raise SystemExit(f"schema validation failed: {exc}") from exc
+
+    if len(cases) < args.min_cases:
+        raise SystemExit(f"expected at least {args.min_cases} cases, found {len(cases)}")
+
+    with tempfile.TemporaryDirectory(prefix="banana-split-corpus-validate-") as tmpdir:
+        tmp_path = Path(tmpdir)
+        try:
+            repos = _clone_repos(cases, tmp_path)
+        except Exception as exc:  # noqa: BLE001
+            raise SystemExit(f"repository clone failed: {exc}") from exc
+
+        metrics: list[CaseMetrics] = []
+        for case in cases:
+            key = (case["repo_url"].strip(), case["branch"].strip())
+            try:
+                case_result = _case_metrics(case, repos[key])
+            except Exception as exc:  # noqa: BLE001
+                raise SystemExit(f"case '{case['name']}' validation failed: {exc}") from exc
+            metrics.append(case_result)
+
+    source_test_count = sum(1 for metric in metrics if metric.source_test_python)
+    test_first_count = sum(1 for metric in metrics if metric.test_first)
+    source_test_ratio = source_test_count / len(metrics)
+
+    print(f"Corpus: {corpus_path}")
+    print(f"Cases: {len(metrics)}")
+    print(f"Source+test Python cases: {source_test_count}/{len(metrics)} ({source_test_ratio:.3f})")
+    print(f"Test-first cases: {test_first_count}")
+
+    failures: list[str] = []
+    if source_test_ratio < args.min_source_test_ratio:
+        failures.append(
+            "source+test ratio too low "
+            f"({source_test_ratio:.3f} < {args.min_source_test_ratio:.3f})"
+        )
+    if test_first_count < args.min_test_first_cases:
+        failures.append(
+            f"test-first case count too low ({test_first_count} < {args.min_test_first_cases})"
+        )
+
+    if failures:
+        print("Validation failed:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("Validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_eval_corpus_fixture.py
+++ b/tests/test_eval_corpus_fixture.py
@@ -1,0 +1,24 @@
+import json
+from pathlib import Path
+
+
+def test_eval_corpus_v1_fixture_meets_baseline_constraints():
+    corpus_path = Path("examples/eval_corpus_v1.json")
+    raw = json.loads(corpus_path.read_text())
+
+    assert isinstance(raw, dict)
+    cases = raw.get("cases")
+    assert isinstance(cases, list)
+    assert len(cases) >= 20
+
+    for case in cases:
+        assert isinstance(case, dict)
+        for field in ["name", "repo_url", "branch", "target", "rationale"]:
+            assert isinstance(case.get(field), str) and case[field].strip()
+        depth = case.get("clone_depth", 200)
+        assert isinstance(depth, int) and depth > 0
+
+    test_first_count = sum(
+        1 for case in cases if "test-first diff order" in case["rationale"].lower()
+    )
+    assert test_first_count >= 5

--- a/tests/test_eval_report_gate.py
+++ b/tests/test_eval_report_gate.py
@@ -22,6 +22,8 @@ def test_check_eval_report_passes_when_thresholds_are_met(tmp_path):
                 "summary": {
                     "tree_equal_success_rate": 1.0,
                     "dependency_order_satisfaction": 0.85,
+                    "expected_dependency_pairs": 20,
+                    "satisfied_dependency_pairs": 17,
                 },
                 "cases": [
                     {"name": "case-a", "status": "success", "tree_equal": True},
@@ -30,8 +32,9 @@ def test_check_eval_report_passes_when_thresholds_are_met(tmp_path):
         )
     )
 
-    proc = _run_gate(report_path, "--min-tree-equal", "1.0")
+    proc = _run_gate(report_path, "--min-tree-equal", "1.0", "--min-dependency-order", "0.8")
     assert proc.returncode == 0
+    assert "dependency_pairs=17/20" in proc.stdout
     assert "Quality gates passed." in proc.stdout
 
 
@@ -43,6 +46,8 @@ def test_check_eval_report_prints_failing_cases_for_tree_equality(tmp_path):
                 "summary": {
                     "tree_equal_success_rate": 0.8,
                     "dependency_order_satisfaction": 0.85,
+                    "expected_dependency_pairs": 20,
+                    "satisfied_dependency_pairs": 17,
                 },
                 "cases": [
                     {
@@ -62,3 +67,46 @@ def test_check_eval_report_prints_failing_cases_for_tree_equality(tmp_path):
     assert "Failing cases:" in proc.stdout
     assert "case-b (apply_failed): patch does not apply" in proc.stdout
     assert "tree_equal_success_rate below threshold" in proc.stdout
+
+
+def test_check_eval_report_fails_dependency_order_threshold(tmp_path):
+    report_path = tmp_path / "report.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "summary": {
+                    "tree_equal_success_rate": 1.0,
+                    "dependency_order_satisfaction": 0.75,
+                    "expected_dependency_pairs": 20,
+                    "satisfied_dependency_pairs": 15,
+                },
+                "cases": [
+                    {"name": "case-a", "status": "success", "tree_equal": True},
+                ],
+            }
+        )
+    )
+
+    proc = _run_gate(report_path, "--min-tree-equal", "1.0", "--min-dependency-order", "0.8")
+    assert proc.returncode == 1
+    assert "dependency_order_satisfaction below threshold" in proc.stdout
+
+
+def test_check_eval_report_requires_dependency_metric_when_gate_enabled(tmp_path):
+    report_path = tmp_path / "report.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "summary": {
+                    "tree_equal_success_rate": 1.0,
+                },
+                "cases": [
+                    {"name": "case-a", "status": "success", "tree_equal": True},
+                ],
+            }
+        )
+    )
+
+    proc = _run_gate(report_path, "--min-dependency-order", "0.8")
+    assert proc.returncode == 1
+    assert "does not include dependency_order_satisfaction" in proc.stderr

--- a/tests/test_eval_report_gate.py
+++ b/tests/test_eval_report_gate.py
@@ -1,0 +1,64 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run_gate(report_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    script = Path(__file__).resolve().parents[1] / "scripts" / "check_eval_report.py"
+    return subprocess.run(
+        [sys.executable, str(script), str(report_path), *args],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_check_eval_report_passes_when_thresholds_are_met(tmp_path):
+    report_path = tmp_path / "report.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "summary": {
+                    "tree_equal_success_rate": 1.0,
+                    "dependency_order_satisfaction": 0.85,
+                },
+                "cases": [
+                    {"name": "case-a", "status": "success", "tree_equal": True},
+                ],
+            }
+        )
+    )
+
+    proc = _run_gate(report_path, "--min-tree-equal", "1.0")
+    assert proc.returncode == 0
+    assert "Quality gates passed." in proc.stdout
+
+
+def test_check_eval_report_prints_failing_cases_for_tree_equality(tmp_path):
+    report_path = tmp_path / "report.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "summary": {
+                    "tree_equal_success_rate": 0.8,
+                    "dependency_order_satisfaction": 0.85,
+                },
+                "cases": [
+                    {
+                        "name": "case-b",
+                        "status": "apply_failed",
+                        "tree_equal": False,
+                        "error": "patch does not apply",
+                    },
+                    {"name": "case-c", "status": "success", "tree_equal": True},
+                ],
+            }
+        )
+    )
+
+    proc = _run_gate(report_path, "--min-tree-equal", "1.0")
+    assert proc.returncode == 1
+    assert "Failing cases:" in proc.stdout
+    assert "case-b (apply_failed): patch does not apply" in proc.stdout
+    assert "tree_equal_success_rate below threshold" in proc.stdout

--- a/tests/test_heuristics_and_planner.py
+++ b/tests/test_heuristics_and_planner.py
@@ -8,7 +8,8 @@ from banana_split.domain import (
     Plan,
     SuggestedCommit,
 )
-from banana_split.planner import _validate_and_order_plan
+from banana_split.git_adapter import GitDiffResult
+from banana_split.planner import _enrich_python_hunk_symbols, _validate_and_order_plan
 from banana_split.errors import PlanValidationError
 
 
@@ -213,3 +214,85 @@ def test_validate_and_order_plan_preserves_cross_file_commit_order():
 
     _validate_and_order_plan(plan)
     assert [commit.id for commit in plan.suggested_commits] == ["src", "test"]
+
+
+def test_enrich_python_hunk_symbols_uses_ast_when_available(monkeypatch):
+    diff = Diff(
+        base_commit="base",
+        target_commit="target",
+        files=[
+            FileDiff(
+                path_old="service.py",
+                path_new="service.py",
+                change_type="modify",
+                is_binary=False,
+                hunks=[
+                    DiffHunk(
+                        id="service.py::h0",
+                        file_path="service.py",
+                        header="@@ -1,2 +1,2 @@ not a real symbol",
+                        lines=[
+                            DiffLine(line_type="-", content="def old_name():", original_lineno=1),
+                            DiffLine(line_type="+", content="def new_name():", new_lineno=1),
+                            DiffLine(line_type="-", content="    return 1", original_lineno=2),
+                            DiffLine(line_type="+", content="    return 2", new_lineno=2),
+                        ],
+                        meta={"language": "python", "symbol": "not a real symbol"},
+                    )
+                ],
+            )
+        ],
+    )
+    git_diff = GitDiffResult(raw_diff="", base_commit="base", target_commit="target")
+
+    monkeypatch.setattr(
+        "banana_split.planner.get_file_content_at_commit",
+        lambda commit, path: (
+            "def old_name():\n    return 1\n"
+            if commit == "base"
+            else "def new_name():\n    return 2\n"
+        ),
+    )
+    monkeypatch.setattr("banana_split.planner.get_staged_file_content", lambda path: None)
+
+    _enrich_python_hunk_symbols(diff=diff, git_diff=git_diff)
+
+    hunk = diff.files[0].hunks[0]
+    assert hunk.meta.get("symbol") == "def new_name"
+
+
+def test_enrich_python_hunk_symbols_falls_back_to_existing_symbol(monkeypatch):
+    diff = Diff(
+        base_commit="base",
+        target_commit="target",
+        files=[
+            FileDiff(
+                path_old="service.py",
+                path_new="service.py",
+                change_type="modify",
+                is_binary=False,
+                hunks=[
+                    DiffHunk(
+                        id="service.py::h0",
+                        file_path="service.py",
+                        header="@@ -1,1 +1,1 @@ def header_symbol",
+                        lines=[DiffLine(line_type="+", content="x = 1", new_lineno=1)],
+                        meta={"language": "python", "symbol": "def header_symbol"},
+                    )
+                ],
+            )
+        ],
+    )
+    git_diff = GitDiffResult(raw_diff="", base_commit="base", target_commit="target")
+
+    # Invalid Python source causes AST parsing to fail, so symbol should remain unchanged.
+    monkeypatch.setattr(
+        "banana_split.planner.get_file_content_at_commit",
+        lambda commit, path: "def broken(:\n    pass\n",
+    )
+    monkeypatch.setattr("banana_split.planner.get_staged_file_content", lambda path: None)
+
+    _enrich_python_hunk_symbols(diff=diff, git_diff=git_diff)
+
+    hunk = diff.files[0].hunks[0]
+    assert hunk.meta.get("symbol") == "def header_symbol"

--- a/tests/test_language_intel.py
+++ b/tests/test_language_intel.py
@@ -1,0 +1,90 @@
+from banana_split.analysis.language_intel import (
+    extract_python_symbol_for_hunk,
+    extract_python_symbol_for_lines,
+)
+from banana_split.domain import DiffHunk, DiffLine
+
+
+def test_extract_python_symbol_for_lines_function():
+    source = (
+        "def compute(x):\n"
+        "    return x + 1\n"
+    )
+
+    symbol = extract_python_symbol_for_lines(source, [2])
+    assert symbol == "def compute"
+
+
+def test_extract_python_symbol_for_lines_method():
+    source = (
+        "class Service:\n"
+        "    def handle(self):\n"
+        "        return 1\n"
+    )
+
+    symbol = extract_python_symbol_for_lines(source, [3])
+    assert symbol == "def Service.handle"
+
+
+def test_extract_python_symbol_for_lines_nested_scope():
+    source = (
+        "def outer():\n"
+        "    x = 1\n"
+        "    def inner():\n"
+        "        return x\n"
+        "    return inner()\n"
+    )
+
+    inner_symbol = extract_python_symbol_for_lines(source, [4])
+    outer_symbol = extract_python_symbol_for_lines(source, [2])
+
+    assert inner_symbol == "def outer.inner"
+    assert outer_symbol == "def outer"
+
+
+def test_extract_python_symbol_for_lines_decorated_function():
+    source = (
+        "@cached\n"
+        "@trace(\"x\")\n"
+        "def work():\n"
+        "    return 1\n"
+    )
+
+    symbol = extract_python_symbol_for_lines(source, [1])
+    assert symbol == "def work"
+
+
+def test_extract_python_symbol_for_lines_returns_none_when_ast_parse_fails():
+    source = (
+        "def broken(:\n"
+        "    return 1\n"
+    )
+    assert extract_python_symbol_for_lines(source, [1, 2]) is None
+
+
+def test_extract_python_symbol_for_hunk_supports_new_and_old_sides():
+    source_old = (
+        "def old_name():\n"
+        "    return 1\n"
+    )
+    source_new = (
+        "def new_name():\n"
+        "    return 2\n"
+    )
+    hunk = DiffHunk(
+        id="foo.py::h0",
+        file_path="foo.py",
+        header="@@ -1,2 +1,2 @@",
+        lines=[
+            DiffLine(line_type="-", content="def old_name():", original_lineno=1, new_lineno=None),
+            DiffLine(line_type="+", content="def new_name():", original_lineno=None, new_lineno=1),
+            DiffLine(line_type="-", content="    return 1", original_lineno=2, new_lineno=None),
+            DiffLine(line_type="+", content="    return 2", original_lineno=None, new_lineno=2),
+        ],
+    )
+
+    symbol_new = extract_python_symbol_for_hunk(hunk, source_new, side="new")
+    symbol_old = extract_python_symbol_for_hunk(hunk, source_old, side="old")
+
+    assert symbol_new == "def new_name"
+    assert symbol_old == "def old_name"


### PR DESCRIPTION
## Summary
- add curated `examples/eval_corpus_v1.json` with 20 dependency-sensitive Python commit cases and rationale metadata
- add `scripts/validate_eval_corpus.py` and a fixture test to validate corpus constraints
- add `Makefile` with `make eval`, `make eval-sample`, and `make validate-eval-corpus`
- add `.github/workflows/eval.yml` to run benchmark on pull requests and upload `artifacts/eval-report.json`
- add `scripts/check_eval_report.py` plus tests to enforce quality gates and print failing cases
- document local and CI eval flows in README

## Gates
- tree-equality gate enforced in eval workflow: `tree_equal_success_rate >= 1.0`

## Validation
- `uv run pytest -q` -> `34 passed, 1 skipped`
- `make eval-sample EVAL_OUTPUT=artifacts/eval-sample-report.json`
- `make validate-eval-corpus EVAL_CORPUS=examples/eval_corpus_v1.json`
- `uv run python scripts/check_eval_report.py artifacts/eval-sample-report.json --min-tree-equal 1.0`

## Related
- #2
- #3
- #4
