### PR TITLE
docs: mention make test shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,12 @@ Run the test suite with:
 uv run pytest
 ```
 
+or:
+
+```bash
+make test
+```
+
 There is also an optional “real repo” integration test. To run it:
 
 ```bash


### PR DESCRIPTION
Small docs-only update: add uv run pytest -q
.........................................s...                            [100%]
44 passed, 1 skipped in 0.78s as a shortcut alongside ============================= test session starts ==============================
platform darwin -- Python 3.9.23, pytest-8.4.2, pluggy-1.6.0
rootdir: /Users/zyadhaddad/Dev/banana-split
configfile: pyproject.toml
collected 45 items

tests/test_apply_plan.py ....                                            [  8%]
tests/test_cli_eval.py ..                                                [ 13%]
tests/test_cli_integration.py .                                          [ 15%]
tests/test_diff_parser.py ....                                           [ 24%]
tests/test_eval_corpus_fixture.py .                                      [ 26%]
tests/test_eval_harness.py ....                                          [ 35%]
tests/test_eval_report_gate.py ....                                      [ 44%]
tests/test_git_adapter.py ..                                             [ 48%]
tests/test_heuristics_and_planner.py .......                             [ 64%]
tests/test_language_intel.py ......                                      [ 77%]
tests/test_preflight.py ......                                           [ 91%]
tests/test_real_repo_integration.py s                                    [ 93%]
tests/test_semantic_atomizer.py ...                                      [100%]

======================== 44 passed, 1 skipped in 0.74s =========================.