### PR TITLE
Add import-based Python source-to-test dependency linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,6 @@ Versioning when stable releases begin.
 - AST-based Python symbol extraction for hunks, including methods, nested
   scopes, and decorator-aware line mapping with safe fallback behavior.
 - GitHub Actions status badges (`CI`, `Eval`) in README.
+- Import-based Python source-to-test dependency linking integrated into
+  semantic ordering, including support for direct imports, from-imports,
+  aliased imports, and package paths.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This is an early prototype, but already supports:
 - AST-based Python symbol extraction with fallback to hunk-header symbols.
 - Semantic atomization with lightweight dependency ordering (for example,
   source-before-test when signals match).
+- Import-based source-to-test dependency linking for Python changes.
 - Building a plan of suggested commits.
 - Simple interactive review (rename commit titles).
 - Replaying the original commit as multiple commits on a new branch,

--- a/banana_split/analysis/language_intel.py
+++ b/banana_split/analysis/language_intel.py
@@ -136,6 +136,52 @@ def extract_python_symbol_for_lines(source: str, line_numbers: Iterable[int]) ->
     return best_symbol
 
 
+def extract_python_import_modules(source: str) -> set[str]:
+    """
+    Extract normalized module references imported by Python source.
+
+    Examples:
+      - `import pkg.service as svc` -> {"pkg.service"}
+      - `from pkg import service` -> {"pkg", "pkg.service"}
+      - `from pkg.service import run` -> {"pkg.service", "pkg.service.run"}
+    """
+
+    try:
+        tree = ast.parse(source)
+    except (SyntaxError, ValueError):
+        return set()
+
+    modules: set[str] = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                normalized = _normalize_module_name(alias.name)
+                if normalized:
+                    modules.add(normalized)
+            continue
+
+        if isinstance(node, ast.ImportFrom):
+            # Relative imports (`from .foo import bar`) are omitted because
+            # resolving them reliably requires package context.
+            if node.level and node.level > 0:
+                continue
+
+            base = _normalize_module_name(node.module)
+            if not base:
+                continue
+            modules.add(base)
+
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                child = _normalize_module_name(f"{base}.{alias.name}")
+                if child:
+                    modules.add(child)
+
+    return modules
+
+
 def _collect_python_symbol_spans(tree: ast.AST) -> list[_PythonSymbolSpan]:
     spans: list[_PythonSymbolSpan] = []
     order_counter = 0
@@ -219,3 +265,10 @@ def _collect_line_numbers(hunk: DiffHunk, *, use_new: bool, changed_line_type: s
             numbers.append(lineno)
     return numbers
 
+
+def _normalize_module_name(name: Optional[str]) -> Optional[str]:
+    if not isinstance(name, str):
+        return None
+
+    normalized = ".".join(part.strip() for part in name.split(".") if part.strip())
+    return normalized or None

--- a/banana_split/analysis/semantic_atomizer.py
+++ b/banana_split/analysis/semantic_atomizer.py
@@ -25,6 +25,7 @@ class _SemanticNode:
     id: str
     file_path: str
     symbol: Optional[str]
+    import_modules: Set[str]
     hunk_ids: List[str]
     tags: Set[str]
     summary: Optional[str]
@@ -43,11 +44,11 @@ def atomize_semantically(diff: Diff) -> List[AtomicChange]:
     """
 
     hunk_order = _build_hunk_order(diff)
-    nodes, by_file, by_symbol, by_module = _build_nodes(diff, hunk_order)
+    nodes, by_file, by_symbol, by_module, by_import_module = _build_nodes(diff, hunk_order)
     if not nodes:
         return []
 
-    edges = _build_dependencies(nodes, by_file, by_symbol, by_module)
+    edges = _build_dependencies(nodes, by_file, by_symbol, by_module, by_import_module)
     ordered_nodes = _topological_sort(nodes, edges)
 
     return [
@@ -79,11 +80,13 @@ def _build_nodes(
     Dict[str, List[_SemanticNode]],
     Dict[str, List[_SemanticNode]],
     Dict[str, List[_SemanticNode]],
+    Dict[str, List[_SemanticNode]],
 ]:
     nodes: List[_SemanticNode] = []
     by_file: Dict[str, List[_SemanticNode]] = {}
     by_symbol: Dict[str, List[_SemanticNode]] = {}
     by_module: Dict[str, List[_SemanticNode]] = {}
+    by_import_module: Dict[str, List[_SemanticNode]] = {}
 
     for file in diff.files:
         if not file.hunks:
@@ -116,10 +119,12 @@ def _build_nodes(
                 summary = f"Changes in {path} ({symbol})"
 
             first_order = min(hunk_order[hid] for hid in hunk_ids)
+            import_modules = _collect_import_modules(hunks)
             node = _SemanticNode(
                 id=f"{path}::ac{idx}",
                 file_path=path,
                 symbol=symbol,
+                import_modules=import_modules,
                 hunk_ids=hunk_ids,
                 tags=node_tags,
                 summary=summary,
@@ -135,9 +140,13 @@ def _build_nodes(
             if module_key:
                 by_module.setdefault(module_key, []).append(node)
 
+            if "test" not in node.tags:
+                for import_key in _module_import_keys_for_path(path):
+                    by_import_module.setdefault(import_key, []).append(node)
+
         by_file[path] = file_nodes
 
-    return nodes, by_file, by_symbol, by_module
+    return nodes, by_file, by_symbol, by_module, by_import_module
 
 
 def _group_hunks_by_symbol(hunks: List[DiffHunk]) -> List[Tuple[Optional[str], List[DiffHunk]]]:
@@ -163,6 +172,7 @@ def _build_dependencies(
     by_file: Dict[str, List[_SemanticNode]],
     by_symbol: Dict[str, List[_SemanticNode]],
     by_module: Dict[str, List[_SemanticNode]],
+    by_import_module: Dict[str, List[_SemanticNode]],
 ) -> Dict[str, Set[str]]:
     node_by_id = {node.id: node for node in nodes}
     edges: Dict[str, Set[str]] = {node.id: set() for node in nodes}
@@ -191,6 +201,16 @@ def _build_dependencies(
                 linked_sources.add(candidate.id)
 
         # If symbol signal is missing, fall back to module name linkage.
+        if not linked_sources:
+            for import_key in node.import_modules:
+                for candidate in by_import_module.get(import_key, []):
+                    if candidate.id == node.id:
+                        continue
+                    if "test" in candidate.tags:
+                        continue
+                    linked_sources.add(candidate.id)
+
+        # Last fallback: simple module-name linkage.
         if not linked_sources:
             module_key = _module_key(node.file_path)
             if module_key:
@@ -286,3 +306,56 @@ def _module_key(path: str) -> Optional[str]:
         lower = lower[: -len("_test")]
     return lower or None
 
+
+def _module_import_keys_for_path(path: str) -> Set[str]:
+    """
+    Build possible import keys for a Python file path.
+
+    Examples:
+      - "service.py" -> {"service"}
+      - "pkg/service.py" -> {"pkg.service", "service"}
+      - "pkg/__init__.py" -> {"pkg"}
+      - "src/app/service.py" -> {"app.service", "service"}
+    """
+
+    pure = Path(path)
+    if pure.suffix.lower() != ".py":
+        return set()
+
+    parts = list(pure.parts)
+    if not parts:
+        return set()
+
+    if parts[-1] == "__init__.py":
+        module_parts = parts[:-1]
+    else:
+        module_parts = [*parts[:-1], pure.stem]
+
+    if not module_parts:
+        return set()
+
+    # Drop common source roots for import-style keys.
+    if module_parts[0] in {"src", "lib"} and len(module_parts) > 1:
+        trimmed = module_parts[1:]
+    else:
+        trimmed = module_parts
+
+    candidates: Set[str] = set()
+    for seq in (module_parts, trimmed):
+        if seq:
+            candidates.add(".".join(seq))
+            candidates.add(seq[-1])
+    return {candidate for candidate in candidates if candidate}
+
+
+def _collect_import_modules(hunks: List[DiffHunk]) -> Set[str]:
+    modules: Set[str] = set()
+    for hunk in hunks:
+        raw = hunk.meta.get("import_modules")
+        if isinstance(raw, list):
+            for entry in raw:
+                if isinstance(entry, str) and entry.strip():
+                    modules.add(entry.strip())
+        elif isinstance(raw, str) and raw.strip():
+            modules.add(raw.strip())
+    return modules

--- a/banana_split/planner.py
+++ b/banana_split/planner.py
@@ -15,7 +15,11 @@ import logging
 
 from .config import Config
 from .domain import Plan
-from .analysis.language_intel import detect_language, extract_python_symbol_for_hunk
+from .analysis.language_intel import (
+    detect_language,
+    extract_python_import_modules,
+    extract_python_symbol_for_hunk,
+)
 from .analysis.heuristics import group_hunks
 from .ai.openai_client import OpenAIClient
 from .diff_parser import parse_unified_diff
@@ -47,7 +51,7 @@ def build_plan(config: Config) -> Plan:
     diff.base_commit = git_diff.base_commit
     diff.target_commit = git_diff.target_commit
     validate_runtime_support(config, git_diff, diff)
-    _enrich_python_hunk_symbols(diff=diff, git_diff=git_diff)
+    _enrich_python_hunk_metadata(diff=diff, git_diff=git_diff)
 
     atomic_changes = group_hunks(diff)
 
@@ -96,9 +100,9 @@ def _obtain_git_diff(config: Config) -> GitDiffResult:
     return get_diff_for_commit(target)
 
 
-def _enrich_python_hunk_symbols(*, diff, git_diff: GitDiffResult) -> None:
+def _enrich_python_hunk_metadata(*, diff, git_diff: GitDiffResult) -> None:
     """
-    Best-effort AST enrichment for Python hunk symbols.
+    Best-effort AST enrichment for Python hunk metadata.
 
     If enrichment fails for any file/hunk, existing symbol metadata
     (for example from hunk headers) remains unchanged.
@@ -117,6 +121,8 @@ def _enrich_python_hunk_symbols(*, diff, git_diff: GitDiffResult) -> None:
         if new_source is None and old_source is None:
             continue
 
+        import_modules = _collect_python_import_modules(new_source)
+
         for hunk in file.hunks:
             symbol = None
             if new_source is not None:
@@ -125,6 +131,8 @@ def _enrich_python_hunk_symbols(*, diff, git_diff: GitDiffResult) -> None:
                 symbol = extract_python_symbol_for_hunk(hunk, old_source, side="old")
             if symbol:
                 hunk.meta["symbol"] = symbol
+            if import_modules:
+                hunk.meta["import_modules"] = sorted(import_modules)
 
 
 def _load_new_side_source(*, path_new: str | None, git_diff: GitDiffResult) -> str | None:
@@ -142,6 +150,12 @@ def _load_old_side_source(*, path_old: str | None, git_diff: GitDiffResult) -> s
     if not path_old or not git_diff.base_commit:
         return None
     return get_file_content_at_commit(git_diff.base_commit, path_old)
+
+
+def _collect_python_import_modules(source: str | None) -> set[str]:
+    if not source:
+        return set()
+    return extract_python_import_modules(source)
 
 
 def _validate_and_order_plan(plan: Plan) -> None:

--- a/tests/test_heuristics_and_planner.py
+++ b/tests/test_heuristics_and_planner.py
@@ -9,7 +9,7 @@ from banana_split.domain import (
     SuggestedCommit,
 )
 from banana_split.git_adapter import GitDiffResult
-from banana_split.planner import _enrich_python_hunk_symbols, _validate_and_order_plan
+from banana_split.planner import _enrich_python_hunk_metadata, _validate_and_order_plan
 from banana_split.errors import PlanValidationError
 
 
@@ -216,7 +216,7 @@ def test_validate_and_order_plan_preserves_cross_file_commit_order():
     assert [commit.id for commit in plan.suggested_commits] == ["src", "test"]
 
 
-def test_enrich_python_hunk_symbols_uses_ast_when_available(monkeypatch):
+def test_enrich_python_hunk_metadata_uses_ast_when_available(monkeypatch):
     diff = Diff(
         base_commit="base",
         target_commit="target",
@@ -255,13 +255,14 @@ def test_enrich_python_hunk_symbols_uses_ast_when_available(monkeypatch):
     )
     monkeypatch.setattr("banana_split.planner.get_staged_file_content", lambda path: None)
 
-    _enrich_python_hunk_symbols(diff=diff, git_diff=git_diff)
+    _enrich_python_hunk_metadata(diff=diff, git_diff=git_diff)
 
     hunk = diff.files[0].hunks[0]
     assert hunk.meta.get("symbol") == "def new_name"
+    assert hunk.meta.get("import_modules") in (None, [])
 
 
-def test_enrich_python_hunk_symbols_falls_back_to_existing_symbol(monkeypatch):
+def test_enrich_python_hunk_metadata_falls_back_to_existing_symbol(monkeypatch):
     diff = Diff(
         base_commit="base",
         target_commit="target",
@@ -292,7 +293,52 @@ def test_enrich_python_hunk_symbols_falls_back_to_existing_symbol(monkeypatch):
     )
     monkeypatch.setattr("banana_split.planner.get_staged_file_content", lambda path: None)
 
-    _enrich_python_hunk_symbols(diff=diff, git_diff=git_diff)
+    _enrich_python_hunk_metadata(diff=diff, git_diff=git_diff)
 
     hunk = diff.files[0].hunks[0]
     assert hunk.meta.get("symbol") == "def header_symbol"
+
+
+def test_enrich_python_hunk_metadata_adds_import_modules(monkeypatch):
+    diff = Diff(
+        base_commit="base",
+        target_commit="target",
+        files=[
+            FileDiff(
+                path_old="tests/test_service.py",
+                path_new="tests/test_service.py",
+                change_type="modify",
+                is_binary=False,
+                hunks=[
+                    DiffHunk(
+                        id="tests/test_service.py::h0",
+                        file_path="tests/test_service.py",
+                        header="@@ -1,1 +1,1 @@",
+                        lines=[DiffLine(line_type="+", content="assert True", new_lineno=4)],
+                        meta={"language": "python"},
+                    )
+                ],
+            )
+        ],
+    )
+    git_diff = GitDiffResult(raw_diff="", base_commit="base", target_commit="target")
+
+    monkeypatch.setattr(
+        "banana_split.planner.get_file_content_at_commit",
+        lambda commit, path: (
+            "from app.service import run\n"
+            "import app.utils as utils\n"
+            "def test_run():\n"
+            "    assert run() is not None\n"
+        ),
+    )
+    monkeypatch.setattr("banana_split.planner.get_staged_file_content", lambda path: None)
+
+    _enrich_python_hunk_metadata(diff=diff, git_diff=git_diff)
+
+    hunk = diff.files[0].hunks[0]
+    modules = hunk.meta.get("import_modules")
+    assert isinstance(modules, list)
+    assert "app.service" in modules
+    assert "app.service.run" in modules
+    assert "app.utils" in modules

--- a/tests/test_language_intel.py
+++ b/tests/test_language_intel.py
@@ -1,4 +1,5 @@
 from banana_split.analysis.language_intel import (
+    extract_python_import_modules,
     extract_python_symbol_for_hunk,
     extract_python_symbol_for_lines,
 )
@@ -88,3 +89,47 @@ def test_extract_python_symbol_for_hunk_supports_new_and_old_sides():
 
     assert symbol_new == "def new_name"
     assert symbol_old == "def old_name"
+
+
+def test_extract_python_import_modules_direct_import():
+    source = (
+        "import service\n"
+        "import pkg.service as svc\n"
+    )
+
+    modules = extract_python_import_modules(source)
+    assert "service" in modules
+    assert "pkg.service" in modules
+
+
+def test_extract_python_import_modules_from_import_and_alias():
+    source = (
+        "from service import run as run_service\n"
+        "from pkg import core as core_mod\n"
+    )
+
+    modules = extract_python_import_modules(source)
+    assert "service" in modules
+    assert "service.run" in modules
+    assert "pkg" in modules
+    assert "pkg.core" in modules
+
+
+def test_extract_python_import_modules_package_paths():
+    source = (
+        "from app.handlers.service import handle\n"
+    )
+
+    modules = extract_python_import_modules(source)
+    assert "app.handlers.service" in modules
+    assert "app.handlers.service.handle" in modules
+
+
+def test_extract_python_import_modules_ignores_relative_imports():
+    source = (
+        "from .service import run\n"
+        "from ..core import utils\n"
+    )
+
+    modules = extract_python_import_modules(source)
+    assert modules == set()

--- a/tests/test_semantic_atomizer.py
+++ b/tests/test_semantic_atomizer.py
@@ -4,10 +4,17 @@ from banana_split.analysis.semantic_atomizer import atomize_semantically
 from banana_split.domain import Diff, DiffHunk, DiffLine, FileDiff
 
 
-def _hunk(hid: str, file_path: str, symbol: Optional[str] = None) -> DiffHunk:
+def _hunk(
+    hid: str,
+    file_path: str,
+    symbol: Optional[str] = None,
+    import_modules: Optional[list[str]] = None,
+) -> DiffHunk:
     meta = {}
     if symbol:
         meta["symbol"] = symbol
+    if import_modules:
+        meta["import_modules"] = import_modules
     return DiffHunk(
         id=hid,
         file_path=file_path,
@@ -97,3 +104,138 @@ def test_atomizer_module_fallback_orders_source_before_test():
     assert len(atomic_changes) == 2
     assert atomic_changes[0].id == "math.py::ac0"
     assert atomic_changes[1].id == "tests/test_math.py::ac0"
+
+
+def test_atomizer_import_link_direct_import_orders_source_before_test():
+    diff = Diff(
+        base_commit="base",
+        target_commit="target",
+        files=[
+            FileDiff(
+                path_old="tests/test_service.py",
+                path_new="tests/test_service.py",
+                change_type="modify",
+                is_binary=False,
+                hunks=[
+                    _hunk(
+                        "tests/test_service.py::h0",
+                        "tests/test_service.py",
+                        symbol=None,
+                        import_modules=["service"],
+                    )
+                ],
+            ),
+            FileDiff(
+                path_old="service.py",
+                path_new="service.py",
+                change_type="modify",
+                is_binary=False,
+                hunks=[_hunk("service.py::h0", "service.py", symbol=None)],
+            ),
+        ],
+    )
+
+    atomic_changes = atomize_semantically(diff)
+    assert [change.id for change in atomic_changes] == ["service.py::ac0", "tests/test_service.py::ac0"]
+
+
+def test_atomizer_import_link_from_import_orders_source_before_test():
+    diff = Diff(
+        base_commit="base",
+        target_commit="target",
+        files=[
+            FileDiff(
+                path_old="tests/test_worker.py",
+                path_new="tests/test_worker.py",
+                change_type="modify",
+                is_binary=False,
+                hunks=[
+                    _hunk(
+                        "tests/test_worker.py::h0",
+                        "tests/test_worker.py",
+                        symbol=None,
+                        import_modules=["worker", "worker.run"],
+                    )
+                ],
+            ),
+            FileDiff(
+                path_old="worker.py",
+                path_new="worker.py",
+                change_type="modify",
+                is_binary=False,
+                hunks=[_hunk("worker.py::h0", "worker.py", symbol=None)],
+            ),
+        ],
+    )
+
+    atomic_changes = atomize_semantically(diff)
+    assert [change.id for change in atomic_changes] == ["worker.py::ac0", "tests/test_worker.py::ac0"]
+
+
+def test_atomizer_import_link_aliased_import_orders_source_before_test():
+    diff = Diff(
+        base_commit="base",
+        target_commit="target",
+        files=[
+            FileDiff(
+                path_old="tests/test_client.py",
+                path_new="tests/test_client.py",
+                change_type="modify",
+                is_binary=False,
+                hunks=[
+                    _hunk(
+                        "tests/test_client.py::h0",
+                        "tests/test_client.py",
+                        symbol=None,
+                        import_modules=["pkg.client"],
+                    )
+                ],
+            ),
+            FileDiff(
+                path_old="pkg/client.py",
+                path_new="pkg/client.py",
+                change_type="modify",
+                is_binary=False,
+                hunks=[_hunk("pkg/client.py::h0", "pkg/client.py", symbol=None)],
+            ),
+        ],
+    )
+
+    atomic_changes = atomize_semantically(diff)
+    assert [change.id for change in atomic_changes] == ["pkg/client.py::ac0", "tests/test_client.py::ac0"]
+
+
+def test_atomizer_import_link_package_path_orders_source_before_test():
+    diff = Diff(
+        base_commit="base",
+        target_commit="target",
+        files=[
+            FileDiff(
+                path_old="tests/test_service_handler.py",
+                path_new="tests/test_service_handler.py",
+                change_type="modify",
+                is_binary=False,
+                hunks=[
+                    _hunk(
+                        "tests/test_service_handler.py::h0",
+                        "tests/test_service_handler.py",
+                        symbol=None,
+                        import_modules=["app.handlers.service", "app.handlers.service.handle"],
+                    )
+                ],
+            ),
+            FileDiff(
+                path_old="app/handlers/service.py",
+                path_new="app/handlers/service.py",
+                change_type="modify",
+                is_binary=False,
+                hunks=[_hunk("app/handlers/service.py::h0", "app/handlers/service.py", symbol=None)],
+            ),
+        ],
+    )
+
+    atomic_changes = atomize_semantically(diff)
+    assert [change.id for change in atomic_changes] == [
+        "app/handlers/service.py::ac0",
+        "tests/test_service_handler.py::ac0",
+    ]


### PR DESCRIPTION
## Summary
- add Python import extraction helper for direct imports, from-imports, aliased imports, and package-path imports
- enrich Python hunks with import metadata during planning
- integrate import-based source-to-test linkage into semantic dependency ordering
- keep existing symbol-based and module-name fallback behavior
- extend tests for planner enrichment, language intel parsing, and semantic ordering edge cases

## Validation
- uv run pytest -q -> 53 passed, 1 skipped
- make eval EVAL_CORPUS=examples/eval_corpus_v1.json EVAL_OUTPUT=artifacts/eval-v1-report.json
- uv run python scripts/check_eval_report.py artifacts/eval-v1-report.json --min-tree-equal 1.0 --min-dependency-order 0.80

## Related
- #7
